### PR TITLE
Added support for AbortController's signals in the watcher

### DIFF
--- a/src/browser/watch.js
+++ b/src/browser/watch.js
@@ -4,7 +4,7 @@ const stream = require('stream');
 const util = require('util');
 const querystring = require('querystring');
 
-module.exports.watch = function watch(config, path, queryParams, callback, done) {
+module.exports.watch = function watch(config, path, queryParams, callback, done, signal) {
     const url = config.getCurrentCluster().server + path;
     queryParams.watch = true;
 
@@ -45,6 +45,7 @@ module.exports.watch = function watch(config, path, queryParams, callback, done)
     const fetchOptions = {
         method: 'GET',
         headers: requestOptions.headers,
+        signal: signal
     };
 
     fetch(url + '?' + querystring.stringify(queryParams), fetchOptions)


### PR DESCRIPTION
The new parameter "signal" is supposed to be an AbortController's signal that, passed in the options of the watch's fetch, can be called at any time to cut the connection of the fetch and so stop the watch